### PR TITLE
Implement support for audience parameter, used when migrating to APIv2.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ Strategy.prototype.authenticate = function (req, options) {
 };
 
 Strategy.prototype.authorizationParams = function(options) {
-  return {connection: options.connection};
+  return {connection: options.connection, audience: options.audience};
 };
 
 


### PR DESCRIPTION
Usage when requesting APIv2 access tokens will be:

```
passport.authenticate('auth0', { audience: 'https://{tenant}.auth0.com/api/v2/' });
```

Requests that don't specify an audience will continue to get tokens for APIv1, ensuring backwards compatibility.