### PR TITLE
Add scope option to return additional metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,12 +37,12 @@ function Strategy(options, verify) {
     }
   });
 
-
   this.options = xtend({}, options, {
     authorizationURL: 'https://' + options.domain + '/authorize',
     tokenURL:         'https://' + options.domain + '/oauth/token',
     userInfoURL:      'https://' + options.domain + '/userinfo',
-    apiUrl:           'https://' + options.domain + '/api'
+    apiUrl:           'https://' + options.domain + '/api',
+    scope:            options.scope && Array.isArray(options.scope) ? options.scope.join(' ') : options.scope
   });
 
 
@@ -74,7 +74,8 @@ Strategy.prototype._getAccessToken = function(done){
     'client_id':     this.options.clientID,
     'client_secret': this.options.clientSecret,
     'type':          'web_server',
-    'grant_type':    'client_credentials'
+    'grant_type':    'client_credentials',
+    'scope':         this.options.scope
   };
 
   request({


### PR DESCRIPTION
Return additional user attributes in the generated token by specifying one or more scopes ([https://auth0.com/docs/scopes])

Example:

`    domain: '<your-domain>.auth0.com',`
`    'clientID': '<your-auth0-clientID>',`
`    'clientSecret': '<your-auth0-clientSecret>',`
`    scope: ['openid', 'email', 'nickname']`
`    // scope: ['openid', 'profile'] //everything`