### PR TITLE
Add scope option to return additional Auth0 profile metadata

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,7 +42,7 @@ function Strategy(options, verify) {
     tokenURL:         'https://' + options.domain + '/oauth/token',
     userInfoURL:      'https://' + options.domain + '/userinfo',
     apiUrl:           'https://' + options.domain + '/api',
-    scope:            options.scope && Array.isArray(options.scope) ? options.scope.join(' ') : 'openid'
+    scope:            options.scope && Array.isArray(options.scope) ? options.scope.join(' ') : options.scope
   });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,12 +37,12 @@ function Strategy(options, verify) {
     }
   });
 
-
   this.options = xtend({}, options, {
     authorizationURL: 'https://' + options.domain + '/authorize',
     tokenURL:         'https://' + options.domain + '/oauth/token',
     userInfoURL:      'https://' + options.domain + '/userinfo',
-    apiUrl:           'https://' + options.domain + '/api'
+    apiUrl:           'https://' + options.domain + '/api',
+    scope:            options.scope && Array.isArray(options.scope) ? options.scope.join(' ') : 'openid'
   });
 
 
@@ -74,7 +74,8 @@ Strategy.prototype._getAccessToken = function(done){
     'client_id':     this.options.clientID,
     'client_secret': this.options.clientSecret,
     'type':          'web_server',
-    'grant_type':    'client_credentials'
+    'grant_type':    'client_credentials',
+    'scope':         this.options.scope
   };
 
   request({

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -7,7 +7,8 @@ describe('auth0 strategy', function () {
        domain:       'jj.auth0.com', 
        clientID:     'testid',
        clientSecret: 'testsecret',
-       callbackURL:  '/callback'
+       callbackURL:  '/callback',
+       scope: ['openid', 'email']
       },
       function(accessToken, idToken, profile, done) {}
     );
@@ -26,6 +27,11 @@ describe('auth0 strategy', function () {
   it('userInfoURL should have the domain', function () {
     this.strategy.options
       .userInfoURL.should.eql('https://jj.auth0.com/userinfo');
+  });
+  
+  it('scope should be flattened to', function () {
+    this.strategy.options
+      .scope.should.eql('openid email');
   });
 
   describe('authorizationParams', function () {


### PR DESCRIPTION
Return additional user attributes in the generated token by specifying one or more scopes ([https://auth0.com/docs/scopes])

Example:

domain: '<your-domain>.auth0.com',
'clientID': '<your-auth0-clientID>',
'clientSecret': '<your-auth0-clientSecret>',
scope: ['openid', 'email', 'nickname']
// scope: ['openid', 'profile'] //everything