### PR TITLE
Support prompt authorization param

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ app.get('/login/google',
 });
 ~~~
 
+If you want to specify an audience for the returned `access_token` you can:
+
+~~~javascript
+app.get('/login',
+  passport.authenticate('auth0', {audience: 'urn:my-api'}), function (req, res) {
+  res.redirect("/");
+});
+~~~
+
+If you want to control the OIDC prompt you can use:
+
+~~~javascript
+app.get('/login',
+  passport.authenticate('auth0', {prompt: 'none'}), function (req, res) {
+  res.redirect("/");
+});
+~~~
+
 ## API access
 
 If you want to get a list of connections or users from auth0, use the [auth0 module](https://github.com/auth0/node-auth0).

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,20 @@ Strategy.prototype.authenticate = function (req, options) {
 };
 
 Strategy.prototype.authorizationParams = function(options) {
-  return {connection: options.connection, audience: options.audience};
+  var options = options || {};
+  
+  var params = {};
+  if (options.connection && typeof options.connection === 'string') {
+    params.connection = options.connection;
+  }
+  if (options.audience && typeof options.audience === 'string') {
+    params.audience = options.audience;
+  }
+  if (options.prompt && typeof options.prompt === 'string') {
+    params.prompt = options.prompt;
+  }
+  
+  return params;
 };
 
 

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -1,5 +1,6 @@
 var Auth10Strategy = require('../lib');
 var assert = require('assert');
+var should = require('should');
 
 describe('auth0 strategy', function () {
   before(function () {
@@ -33,6 +34,41 @@ describe('auth0 strategy', function () {
     it('should map the connection field', function () {
       var extraParams = this.strategy.authorizationParams({connection: 'foo'});
       extraParams.connection.should.eql('foo');
+    });
+
+    it('should not map the connection field if its not a string', function () {
+      var extraParams = this.strategy.authorizationParams({connection: 42});
+      should.not.exist(extraParams.connection);
+    });
+
+    it('should map the audience field', function () {
+      var extraParams = this.strategy.authorizationParams({audience: 'foo'});
+      extraParams.audience.should.eql('foo');
+    });
+
+    it('should not map the audience field if its not a string', function () {
+      var extraParams = this.strategy.authorizationParams({audience: 42});
+      should.not.exist(extraParams.audience);
+    });
+
+    it('should map the prompt field', function () {
+      var extraParams = this.strategy.authorizationParams({prompt: 'foo'});
+      extraParams.prompt.should.eql('foo');
+    });
+
+    it('should not map the prompt field if its not a string', function () {
+      var extraParams = this.strategy.authorizationParams({prompt: 42});
+      should.not.exist(extraParams.prompt);
+    });
+
+    it("shouldn't map any fields if non were specified", function () {
+      var extraParams = this.strategy.authorizationParams({});
+      Object.keys(extraParams).length.should.eql(0);
+    });
+
+    it("should treat no options as empty options", function () {
+      var extraParams = this.strategy.authorizationParams(undefined);
+      Object.keys(extraParams).length.should.eql(0);
     });
 
   });


### PR DESCRIPTION
Auth0 now supports the OIDC `prompt` [parameter](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest):

```
prompt
  OPTIONAL. Space delimited, case sensitive list of ASCII string values that specifies whether the Authorization Server prompts the End-User for reauthentication and consent.
```

You can use to do something like `prompt=node` where no login form will be displayed if an SSO session already exists.