### PR TITLE
Add support for `connection_scope` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ app.get('/login/google',
 });
 ~~~
 
+If you force an identity provider you can also request custom scope from that identity provider:
+
+~~~javascript
+app.get('/login/google', passport.authenticate('auth0', {
+  connection: 'google-oauth2',
+  connection_scope: 'https://www.googleapis.com/auth/analytics, https://www.googleapis.com/auth/contacts.readonly'
+}), function (req, res) {
+  res.redirect("/");
+});
+~~~
+
 If you want to specify an audience for the returned `access_token` you can:
 
 ~~~javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,10 @@ Strategy.prototype.authorizationParams = function(options) {
   var params = {};
   if (options.connection && typeof options.connection === 'string') {
     params.connection = options.connection;
+
+    if (options.connection_scope && typeof options.connection_scope === 'string') {
+      params.connection_scope = options.connection_scope;
+    }
   }
   if (options.audience && typeof options.audience === 'string') {
     params.audience = options.audience;

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -45,6 +45,29 @@ describe('auth0 strategy', function () {
       should.not.exist(extraParams.connection);
     });
 
+    it('should map the connection_scope field', function () {
+      var extraParams = this.strategy.authorizationParams({
+        connection: 'foo',
+        connection_scope: 'foo'
+      });
+      extraParams.connection_scope.should.eql('foo');
+    });
+
+    it('should not map the connection_scope field if connection is not set', function () {
+      var extraParams = this.strategy.authorizationParams({
+        connection_scope: 'foo'
+      });
+      should.not.exist(extraParams.connection_scope);
+    });
+
+    it('should not map the connection_scope field if its not a string', function () {
+      var extraParams = this.strategy.authorizationParams({
+        connection: 'foo',
+        connection_scope: 42
+      });
+      should.not.exist(extraParams.connection_scope);
+    });
+
     it('should map the audience field', function () {
       var extraParams = this.strategy.authorizationParams({audience: 'foo'});
       extraParams.audience.should.eql('foo');


### PR DESCRIPTION
ATM it does not seem possible to specify the desired connection_scope if you want to deviate from the default configured in your auth0 account