### PR TITLE
add support for acr_values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,9 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.login_hint && typeof options.login_hint === 'string') {
     params.login_hint = options.login_hint;
   }
+  if (options.acr_values && typeof options.acr_values === 'string') {
+    params.acr_values = options.acr_values;
+  }
   
   return params;
 };

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -85,6 +85,20 @@ describe('auth0 strategy', function () {
       should.not.exist(extraParams.login_hint);
     });
 
+    it('should map the acr_values field', function () {
+      var extraParams = this.strategy.authorizationParams({acr_values: 'dummy:1'});
+      extraParams.acr_values.should.eql('dummy:1');
+    });
+
+    it('should not map the acr_values field if its not a string', function () {
+      var extraParams = this.strategy.authorizationParams({acr_values: 1});
+      should.not.exist(extraParams.acr_values);
+    });
+
+    it('should not map the acr_values field when not specified in options', function () {
+      var extraParams = this.strategy.authorizationParams({});
+      should.not.exist(extraParams.acr_values);
+    });
   });
 
   describe('authenticate', function () { 


### PR DESCRIPTION
### Changes

Add support to pass acr_values to idp
https://openid.net/specs/openid-connect-core-1_0.html

### References

https://auth0.com/docs/connections/pass-parameters-to-idps

### Testing

- [x] This change adds test coverage

- [x] This change has been tested on the latest stable version of Node.js

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
