### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ A complete example of using this library is shown [here](http://github.com/auth0
 
 For more information about [Auth0](http://auth0.com) contact our [documentation page](http://docs.auth0.com/).
 
+You can also see fully working demos using this library in our [Auth0 blog](https://auth0.com/blog/):
+
+* [Build and Authenticate a Node.js App with JSON Web Tokens](https://auth0.com/blog/building-and-authenticating-nodejs-apps/#nodejs-directory-structure)
+
+* [Developing a Real-Time, Collaborative Editor with Pusher
+](https://auth0.com/blog/developing-a-real-time-collaborative-editor-with-pusher/)
+
 ## Issue Reporting
 
 If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.

--- a/README.md
+++ b/README.md
@@ -109,15 +109,26 @@ app.get('/login',
 
 If you want to get a list of connections or users from Auth0, [use the Node.js SDK](https://github.com/auth0/node-auth0).
 
-## Documentation
-
-For more information about [Auth0](http://auth0.com) contact our [documentation page](http://docs.auth0.com/).
+## Examples
 
 You can also see fully working demos using this library in our [Auth0 blog](https://auth0.com/blog/):
 
 * [Build and Authenticate a Node.js App with JSON Web Tokens](https://auth0.com/blog/building-and-authenticating-nodejs-apps/#nodejs-directory-structure)
 
 * [Developing a Real-Time, Collaborative Editor with Pusher](https://auth0.com/blog/developing-a-real-time-collaborative-editor-with-pusher/)
+
+## What is Auth0?
+
+Auth0 helps you to easily:
+
+- implement authentication with multiple identity providers, including social (e.g., Google, Facebook, Microsoft, LinkedIn, GitHub, Twitter, etc), or enterprise (e.g., Windows Azure AD, Google Apps, Active Directory, ADFS, SAML, etc.)
+- log in users with username/password databases, passwordless, or multi-factor authentication
+- link multiple user accounts together
+- generate signed JSON Web Tokens to authorize your API calls and flow the user identity securely
+- access demographics and analytics detailing how, when, and where users are logging in
+- enrich user profiles from other data sources using customizable JavaScript rules
+
+[Why Auth0?](https://auth0.com/why-auth0)
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/auth0/passport-auth0.svg?branch=master)](https://travis-ci.org/auth0/passport-auth0)
 
-This is the Auth0 authentication strategy for Passport.js.
+This is the [Auth0](https://auth0.com/) authentication strategy for Passport.js.
 
 ## Passport.js
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This is the [Auth0](https://auth0.com/) authentication strategy for Passport.js.
 
 ## Passport.js
 
-[Passport](http://passportjs.org/) is authentication middleware for Node.js. Passport can be unobtrusively dropped in to any Express-based web application.
+[Passport](http://passportjs.org/) is authentication middleware for Node.js. Passport can be unobtrusively dropped into any Express-based web application.
 
 ## Installation
 
-	npm install passport-auth0
+    npm install passport-auth0
 
 ## Configuration
 
-Take your credentials from the [settings](https://app.auth0.com/#/settings) section in the dashboard and initialize the strategy as follows:
+Take your credentials from the _Settings_ tab of your [Auth0 application](https://manage.auth0.com/#/applications/) in the dashboard and initialize the strategy as follows:
 
 ~~~js
 var Auth0Strategy = require('passport-auth0'),
@@ -39,7 +39,7 @@ passport.use(strategy);
 
 ### State parameter
 
-The Auth0 Passport strategy enforces use of `state` parameter in OAuth 2.0 [authorization requests](https://tools.ietf.org/html/rfc6749#section-4.1.1) and requires session support in Express to be enabled.
+The Auth0 Passport strategy enforces the use of the `state` parameter in OAuth 2.0 [authorization requests](https://tools.ietf.org/html/rfc6749#section-4.1.1) and requires session support in Express to be enabled.
 
 If you require the `state` parameter to be omitted (which is not recommended), you can suppress it when calling the Auth0 Passport strategy constructor:
 
@@ -76,7 +76,7 @@ app.get('/login',
 });
 ~~~
 
-This way when you go to ```/login``` you will get redirected to Auth0, to a page where you can select the identity provider.
+This way when you go to ```/login```, you will get redirected to an Auth0 page where you can select the identity provider.
 
 If you want to force an identity provider you can use:
 
@@ -111,7 +111,7 @@ If you want to get a list of connections or users from Auth0, use the [Auth0 mod
 
 ## Complete example
 
-A complete example of using this library [here](http://github.com/auth0/passport-auth0).
+A complete example of using this library is shown [here](http://github.com/auth0/passport-auth0).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ app.get('/login',
 });
 ~~~
 
-This way when you go to ```/login``` you will get redirected to auth0, to a page where you can select the identity provider.
+This way when you go to ```/login``` you will get redirected to Auth0, to a page where you can select the identity provider.
 
 If you want to force an identity provider you can use:
 
@@ -107,7 +107,7 @@ app.get('/login',
 
 ## API access
 
-If you want to get a list of connections or users from auth0, use the [auth0 module](https://github.com/auth0/node-auth0).
+If you want to get a list of connections or users from Auth0, use the [Auth0 module](https://github.com/auth0/node-auth0).
 
 ## Complete example
 
@@ -115,7 +115,7 @@ A complete example of using this library [here](http://github.com/auth0/passport
 
 ## Documentation
 
-For more information about [auth0](http://auth0.com) contact our [documentation page](http://docs.auth0.com/).
+For more information about [Auth0](http://auth0.com) contact our [documentation page](http://docs.auth0.com/).
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ app.get('/login',
 });
 ~~~
 
-This way when you go to ```/login```, you will get redirected to an Auth0 page where you can select the identity provider.
+This way when you go to `/login`, you will get redirected to an Auth0 page where you can select the identity provider.
 
 If you want to force an identity provider you can use:
 
@@ -107,11 +107,7 @@ app.get('/login',
 
 ## API access
 
-If you want to get a list of connections or users from Auth0, use the [Auth0 module](https://github.com/auth0/node-auth0).
-
-## Complete example
-
-A complete example of using this library is shown [here](http://github.com/auth0/passport-auth0).
+If you want to get a list of connections or users from Auth0, [use the Node.js SDK](https://github.com/auth0/node-auth0).
 
 ## Documentation
 
@@ -121,8 +117,7 @@ You can also see fully working demos using this library in our [Auth0 blog](http
 
 * [Build and Authenticate a Node.js App with JSON Web Tokens](https://auth0.com/blog/building-and-authenticating-nodejs-apps/#nodejs-directory-structure)
 
-* [Developing a Real-Time, Collaborative Editor with Pusher
-](https://auth0.com/blog/developing-a-real-time-collaborative-editor-with-pusher/)
+* [Developing a Real-Time, Collaborative Editor with Pusher](https://auth0.com/blog/developing-a-real-time-collaborative-editor-with-pusher/)
 
 ## Issue Reporting
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/auth0/passport-auth0.svg?branch=master)](https://travis-ci.org/auth0/passport-auth0)
 
-This is the auth0 authentication strategy for Passport.js.
+This is the Auth0 authentication strategy for Passport.js.
 
 ## Passport.js
 


### PR DESCRIPTION
### Changes

- Fix typo. Capitalize "auth0"

### References

- "Auth0" is the proper trade name: [https://auth0.com/](https://auth0.com/)

### Testing

Not applicable.

### Checklist

[ X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[ X ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[ X ] All existing and new tests complete without errors
