### PR TITLE
add username to profile

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -5,6 +5,7 @@ function Profile (data, raw) {
   }
   
   this.displayName = data.name,
+  this.username = data.name,
   this.id = data.user_id || data.sub;
   this.user_id = this.id;
 


### PR DESCRIPTION
Found this module does not work with passport in Node-RED without the username attribute appearing in the profile. See Okta's implementation to compare - it presents username in the profile and works in Node-RED as-is

### Changes

Added username attribute to profile object

### References

Compare to Okta implementation

### Testing

Trivial change, not sure how it would be added to tests

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
