### PR TITLE
Add telemetry

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,14 +7,16 @@ var util = require('util'),
   pkg = require('../package.json');
 
 function encodeClientInfo(obj) {
-  var str = JSON.stringify(obj);
-  return new Buffer(str).toString('base64')
-      .replace(/\+/g, '-') // Convert '+' to '-'
-      .replace(/\//g, '_') // Convert '/' to '_'
-      .replace(/=+$/, ''); // Remove ending '='
+  return new Buffer(JSON.stringify(obj)).toString('base64');
 }
 
-var clientInfoHeader = encodeClientInfo({ name: 'passport-auth0', version: pkg.version });
+var clientInfoHeader = encodeClientInfo({
+  name: 'passport-auth0',
+  version: pkg.version,
+  env: {
+    node: process.version
+  }
+});
 
 var Profile = require('./Profile');
 
@@ -36,12 +38,19 @@ function Strategy(options, verify) {
     }
   });
 
-  this.options = Object.assign(options, {
+  options.customHeaders = Object.assign(
+    { 'Auth0-Client': clientInfoHeader },
+    typeof options.customHeaders === 'object' ? options.customHeaders : {}
+  );
+
+  var defaultOptions = {
     authorizationURL: 'https://' + options.domain + '/authorize',
     tokenURL:         'https://' + options.domain + '/oauth/token',
     userInfoURL:      'https://' + options.domain + '/userinfo',
     apiUrl:           'https://' + options.domain + '/api'
-  });
+  }
+
+  this.options = Object.assign(options, defaultOptions);
 
   if (this.options.state === undefined) {
     this.options.state = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ var util = require('util'),
   pkg = require('../package.json');
 
 function encodeClientInfo(obj) {
-  return new Buffer(JSON.stringify(obj)).toString('base64');
+  return Buffer.from(JSON.stringify(obj)).toString('base64');
 }
 
 var clientInfoHeader = encodeClientInfo({


### PR DESCRIPTION
### Changes

Add telemetry for the auth code exchange and corrects the encoding (was stripping out essential characters used for URL-safe encoding [which is not needed as this sends it as a header]).

![Screenshot 2019-07-15 15 34 51](https://user-images.githubusercontent.com/855223/61253514-1f6f0780-a716-11e9-8e41-4ecf1996999a.png)

### Testing

- [x] This change adds test coverage
- [x] This change has been tested on the latest stable version of Node.js

### Checklist

- [x] All existing and new tests complete without errors
