### PR TITLE
Fix strategy constructor to not mutate options argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,7 +50,7 @@ function Strategy(options, verify) {
     apiUrl:           'https://' + options.domain + '/api'
   }
 
-  this.options = Object.assign(options, defaultOptions);
+  this.options = Object.assign({}, options, defaultOptions);
 
   if (this.options.state === undefined) {
     this.options.state = true;

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -49,6 +49,22 @@ describe('auth0 strategy', function () {
     this.strategy.options.state.should.be.true();
   });
 
+  it('should copy options object without mutating', function () {
+    var options = {
+      domain:       'test.auth0.com',
+      clientID:     'testid',
+      clientSecret: 'testsecret',
+      callbackURL:  '/callback'
+    };
+    var strategy = new Auth0Strategy(
+      options,
+      function(accessToken, idToken, profile, done) {}
+    );
+
+    strategy.options.should.be.not.equal(options);
+    options.should.not.have.property('authorizationURL');
+  });
+
   describe('authorizationParams', function () {
 
     it('should map the connection field', function () {


### PR DESCRIPTION
### Description

Fix Strategy constructor to copy the options argument object instead of mutating it. Includes a new unit test to confirm this behavior.

### References

Fixes issue #91.

### Testing

- [X] This change adds test coverage for fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All existing and new tests complete without errors
