### PR TITLE
Add support for `initialPage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ app.get(
 );
 ```
 
+### initialPage
+
+If you want to change initial Page to sign up, set `mode` or `initialPage`(hosted):
+Values should be matched `login`, `signUp`, and `forgotPassword`
+
+[lock-v11-configuration](https://auth0.com/docs/libraries/lock/v11/configuration#initialscreen-string-)
+
+```js
+    '/signup',
+	passport.authenticate('auth0', {initialPage: 'signUp'}), 
+	function (req, res) {
+		res.redirect('/');
+	}
+
+
+``` 
+
 ## Support + Feedback
 
 - Use [Issues](https://github.com/auth0/passport-auth0/issues) for code-level support

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,12 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.acr_values && typeof options.acr_values === 'string') {
     params.acr_values = options.acr_values;
   }
+  if (options.mode && typeof options.mode === 'string') {
+    params.mode = options.mode;
+  }
+  if (options.initialPage && typeof options.initialPage === 'string') {
+    params.initialPage = options.initialPage;
+  }
 
   return params;
 };

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -154,6 +154,18 @@ describe('auth0 strategy', function () {
       var extraParams = this.strategy.authorizationParams({});
       should.not.exist(extraParams.acr_values);
     });
+
+    it('should not map the mode field as string ', function () {
+      var extraParams = this.strategy.authorizationParams({mode: 'signUp'});
+      should.not.exist(extraParams.mode);
+    });
+
+    it('should not map the mode initialPage as string', function () {
+      var extraParams = this.strategy.authorizationParams({initialPage: 'signUp'});
+      should.not.exist(extraParams.initialPage);
+    });
+
+
   });
 
   describe('authenticate', function () {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -157,12 +157,12 @@ describe('auth0 strategy', function () {
 
     it('should not map the mode field as string ', function () {
       var extraParams = this.strategy.authorizationParams({mode: 'signUp'});
-      should.not.exist(extraParams.mode);
+      extraParams.mode.should.eql('signUp');
     });
 
     it('should not map the mode initialPage as string', function () {
       var extraParams = this.strategy.authorizationParams({initialPage: 'signUp'});
-      should.not.exist(extraParams.initialPage);
+      extraParams.initialPage.should.eql('signUp');
     });
 
 


### PR DESCRIPTION
Direct to signUp page with initialPage options
Lock has this options but it didn't have these options . 

Ref [lock/v11/configuration#initialscreen-string](https://auth0.com/docs/libraries/lock/v11/configuration#initialscreen-string-)
