### PR TITLE
Fix decoding jwt when encoded payload contains utf8 characters

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -1,5 +1,5 @@
 var urlDecodeB64 = function(data) {
-  return Buffer.from(data, 'base64').toString('ascii');
+  return Buffer.from(data, 'base64').toString('utf8');
 }
 
 /**

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -83,7 +83,7 @@ function generateJWT(bodyOverrides, alg){
 describe('jwt.decode', function() {
   it('should decode a valid token', function() {
     var alg = 'RS256';
-    var token = generateJWT({}, alg);
+    var token = generateJWT({name: 'ÁÁutf8'}, alg);
     var decoded = jwt.decode(token);
 
     assert.equal(decoded._raw, token);


### PR DESCRIPTION
### Description

This PR fixes a bug where social logins or sign ups do not work when the name of a given account contains utf-8 characters, like 'Á'.

### References

Closes #100 

### Testing

See Issue #100 

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- none required
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
