### PR TITLE
Guard against undefined parameter access

### DIFF
--- a/lib/verifyWrapper.js
+++ b/lib/verifyWrapper.js
@@ -35,7 +35,7 @@ function verifyWrapper (verify, strategyOptions, authParams) {
  * @param {Object} params 
  */
 function handleIdTokenValidation (strategyOptions, authParams, params) {
-  if (authParams.scope && authParams.scope.includes('openid')) {
+  if (authParams && authParams.scope && authParams.scope.includes('openid')) {
     jwt.verify(params.id_token, {
       aud: strategyOptions.clientID,
       iss: 'https://' + strategyOptions.domain + '/',


### PR DESCRIPTION
Upgrading from 1.2.1 to 1.3.1 broke login on my Express app.
This change fixed that and now the login works.

Closes #107, #106
