### PR TITLE
Fix missing ID causing cannot read error

### DIFF
--- a/lib/Profile.js
+++ b/lib/Profile.js
@@ -5,7 +5,7 @@ function Profile(data, raw) {
 
   if (data.identities) {
     this.provider = data.identities[0].provider;
-  } else {
+  } else if (typeof this.id === 'string' && this.id.indexOf('|') > -1 ) {
     this.provider = this.id.split('|')[0];
   }
 

--- a/test/fixtures/auth0-example-profile-no-identities.json
+++ b/test/fixtures/auth0-example-profile-no-identities.json
@@ -1,11 +1,11 @@
 {
-  "email": "jfromaniello@gmail.com",
-  "family_name": "Romaniello",
-  "gender": "male",
-  "given_name": "José F.",
-  "locale": "en",
-  "name": "José F. Romaniello",
-  "nickname": "jfromaniello",
-  "picture": "https://lh3.googleusedasdas.fdasdsa",
-  "user_id": "google-oauth2|ddddd123123123"
+  "email": "__test_email__",
+  "family_name": "__test_family_name__",
+  "gender": "__test_gender__",
+  "given_name": "__test_given_name__",
+  "locale": "__test_locale__",
+  "name": "__test_name__",
+  "nickname": "__test_nickname__",
+  "picture": "__test_picture__",
+  "user_id": "__test_provider__|__test_user_id__"
 }

--- a/test/fixtures/auth0-example-profile.json
+++ b/test/fixtures/auth0-example-profile.json
@@ -1,20 +1,19 @@
 {
-  "email": "jfromaniello@gmail.com",
-  "family_name": "Romaniello",
-  "gender": "male",
-  "given_name": "José F.",
+  "email": "__test_email__",
+  "family_name": "__test_family_name__",
+  "gender": "__test_gender__",
+  "given_name": "__test_given_name__",
   "identities": [
     {
-      "access_token": "aaaaccceesss",
-      "provider": "google-oauth2",
-      "user_id": "ddddd123123123",
-      "connection": "google-oauth2",
+      "provider": "__test_provider__",
+      "user_id": "__test_user_id__",
+      "connection": "__test_provider__",
       "isSocial": true
     }
   ],
-  "locale": "en",
-  "name": "José F. Romaniello",
-  "nickname": "jfromaniello",
-  "picture": "https://lh3.googleusedasdas.fdasdsa",
-  "user_id": "google-oauth2|ddddd123123123"
+  "locale": "__test_locale__",
+  "name": "__test_name__",
+  "nickname": "__test_nickname__",
+  "picture": "__test_picture__",
+  "user_id": "__test_provider__|__test_user_id__"
 }

--- a/test/fixtures/auth0-oidc-example-profile.json
+++ b/test/fixtures/auth0-oidc-example-profile.json
@@ -1,20 +1,19 @@
 {
-  "email": "jfromaniello@gmail.com",
-  "family_name": "Romaniello",
-  "gender": "male",
-  "given_name": "José F.",
+  "email": "__test_email__",
+  "family_name": "__test_family_name__",
+  "gender": "__test_gender__",
+  "given_name": "__test_given_name__",
   "identities": [
     {
-      "access_token": "aaaaccceesss",
-      "provider": "google-oauth2",
-      "user_id": "ddddd123123123",
-      "connection": "google-oauth2",
+      "provider": "__test_provider__",
+      "user_id": "__test_user_id__",
+      "connection": "__test_provider__",
       "isSocial": true
     }
   ],
-  "locale": "en",
-  "name": "José F. Romaniello",
-  "nickname": "jfromaniello",
-  "picture": "https://lh3.googleusedasdas.fdasdsa",
-  "sub": "google-oauth2|ddddd123123123"
+  "locale": "__test_locale__",
+  "name": "__test_name__",
+  "nickname": "__test_nickname__",
+  "picture": "__test_picture__",
+  "sub": "__test_provider__|__test_user_id__"
 }

--- a/test/userprofile.tests.js
+++ b/test/userprofile.tests.js
@@ -3,34 +3,66 @@ var auth0ProfileNoIdentites = require('./fixtures/auth0-example-profile-no-ident
 var auth0OIDCProfile = require('./fixtures/auth0-oidc-example-profile');
 var Profile = require('../lib/Profile');
 
-describe('Profile', function () {
+describe('Standard profiles', function () {
   [auth0Profile, auth0ProfileNoIdentites, auth0OIDCProfile].forEach(function(profile) {
     before(function () {
       this.profile = new Profile(profile);
     });
-  
+
     [
-      ['provider', 'google-oauth2'],
-      ['id', 'google-oauth2|ddddd123123123'],
-      ['user_id', 'google-oauth2|ddddd123123123'],
-      ['displayName', 'José F. Romaniello']
+      ['provider', '__test_provider__'],
+      ['id', '__test_provider__|__test_user_id__'],
+      ['user_id', '__test_provider__|__test_user_id__'],
+      ['displayName', '__test_name__']
     ].forEach(function(tuple) {
       it('should map ' + tuple[0], function () {
         this.profile[tuple[0]]
           .should.eql(tuple[1]);
       });
     });
-  
+
     it('should map the name', function () {
       this.profile.name.givenName
-          .should.eql('José F.');
+          .should.eql('__test_given_name__');
       this.profile.name.familyName
-          .should.eql('Romaniello');
+          .should.eql('__test_family_name__');
     });
-  
-    it('should map the emails', function () { 
+
+    it('should map the emails', function () {
       this.profile.emails[0]
-        .value.should.eql('jfromaniello@gmail.com');
+        .value.should.eql('__test_email__');
     });
   });
 });
+
+describe('Non-standard profiles', function () {
+
+  describe('Profile without an ID', function () {
+    const profile = new Profile({email: '__test_email__'});
+
+    it('should have no provider', function () {
+      profile.should.not.have.property('provider');
+    });
+  });
+
+  describe('Profile without a provider in the user ID', function () {
+    const profile = new Profile({sub: '__test_sub__'});
+
+    it('should have no provider', function () {
+      profile.should.not.have.property('provider');
+    });
+
+    it('should have the correct ID', function () {
+      profile.id.should.eql('__test_sub__');
+    });
+  });
+
+  describe('Profile without an email', function () {
+    const profile = new Profile({sub: '__test_sub__'});
+
+    it('should have no emails', function () {
+      profile.should.not.have.property('emails');
+    });
+  });
+});
+


### PR DESCRIPTION
### Description

The `id` of the Passport profile should be a string but if the `openid` scope is not used during login, a profile may still be returned. This PR fixes the error during callback caused by a missing `sub` and `user_id` on the returned profile. Additionally, it checks for the split character to make sure that `provider` is not set to the `id`.

Developers should use the `openid` scope but this strategy should enforce that at startup, not fail during callback.

### References

Closes #105 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality