### PR TITLE
Feature/allow theme parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,46 @@ app.get(
 );
 ```
 
+### Theme options
+
+To pass theme props to the Universal login, add the following:
+See [Theme documentation](https://auth0.com/docs/libraries/lock/v11/configuration#theme-object-). for more options.
+
+##### 1. Set the theme when initiating the strategy
+```js
+new Strategy({
+      // ...
+    theme: {
+      logo: '://url.com/logo.png'
+    },
+  }, (accessToken, refreshToken, extraParams, profile, done) => {
+    done(null, profile)
+  }
+```
+##### 2. Overwrite the theme when calling the login endpoint (Optional)
+
+```js
+const options = {
+  theme: {
+    logo: '://url.com/logo.png'
+  }
+};
+
+app.get('/login', passport.authenticate('auth0', options), 
+  function (req, res) {
+    res.redirect('/');
+  }
+);
+```
+
+##### 3. Customize [Login page](https://manage.auth0.com/dashboard/eu/leaseplan-menno/login_page)
+After passing the theme you will be able to use the theme object in the Universal Login template by parsing `config.extraParams.theme` by changing the template on line `57`:
+
+```js
+theme: config && config.extraParams && config.extraParams.theme ? JSON.parse(config.extraParams.theme) : {},
+```
+
+
 ## Support + Feedback
 
 - Use [Issues](https://github.com/auth0/passport-auth0/issues) for code-level support

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,6 +111,14 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.acr_values && typeof options.acr_values === 'string') {
     params.acr_values = options.acr_values;
   }
+  if(options.theme) {
+    if(typeof options.theme === 'string') {
+      params.theme = options.theme
+    }
+    if (typeof options.theme === 'object' && !Array.isArray(options.theme)) {
+      params.theme = JSON.stringify(options.theme)
+    }
+  }
 
   var strategyOptions = this.options;
   if (strategyOptions && typeof strategyOptions.maxAge === 'number') {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -187,6 +187,26 @@ describe('auth0 strategy', function () {
       var extraParams = this.strategy.authorizationParams({});
       should.not.exist(extraParams.max_age);
     });
+
+    it('should map the theme field when passed as a string', function () {
+      var extraParams = this.strategy.authorizationParams({theme: '{"logo":"http://website.com/logo.png"}'});
+      extraParams.theme.should.eql('{"logo":"http://website.com/logo.png"}');
+    });
+
+    it('should convert the theme field to a string when passed as an object', function () {
+      var extraParams = this.strategy.authorizationParams({theme: {logo: 'http://website.com/logo.png'}});
+      extraParams.theme.should.eql('{"logo":"http://website.com/logo.png"}');
+    });
+
+    it('should not map the theme field when passed as an integer', function () {
+      var extraParams = this.strategy.authorizationParams({theme: 100});
+      should.not.exist(extraParams.theme);
+    });
+
+    it('should not map the theme field when passed as an array', function () {
+      var extraParams = this.strategy.authorizationParams({theme: ["foo", "bar"]});
+      should.not.exist(extraParams.theme);
+    });
   });
 
   describe('authenticate', function () {


### PR DESCRIPTION
### Description

This will allow users to pass the `theme` prop to the Strategy as a stringified or a regular object. This will be passed to the Universal login screen under `config.extraParams.theme`.

Passing the theme prop, users will be able to add customisations as described here: https://auth0.com/docs/libraries/lock/v11/configuration#theme-object-

### References

> - https://auth0.com/docs/libraries/lock/v11/configuration#theme-object-


### Testing
(See readme for extended info)
This is a 2 step process:
1. In the client application; pass the theme object with allowed parameters to the Strategy. E.g.:
`
 const auth0Strategy = new Strategy(
    {
      ...defaultConfigOptions
      theme: { logo: "url.com/logo.png" },
    },
    (_accessToken, _refreshToken, _extraParams, profile, done) => {
      done(null, profile)
    },
  )
`

2. In auth0 management application; Customise the Universal login template to get theme info from the config object.
Change the following on line 57 of the login template:
`theme: config && config.extraParams && config.extraParams.theme ? JSON.parse(config.extraParams.theme) : {},`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
