### PR TITLE
Remove ID token `iat` value check

### DIFF
--- a/lib/jwt.js
+++ b/lib/jwt.js
@@ -46,7 +46,7 @@ var verify = (token, options) => {
   }
 
   var payload = decodedToken.payload;
-  
+
   // Issuer
   if (!payload.iss || typeof payload.iss !== 'string') {
     throw new Error('Issuer (iss) claim must be a string present in the ID token');
@@ -59,7 +59,7 @@ var verify = (token, options) => {
   if (!payload.sub || typeof payload.sub !== 'string') {
     throw new Error('Subject (sub) claim must be a string present in the ID token');
   }
-  
+
   // Audience
   if (!payload.aud || !(typeof payload.aud === 'string' || Array.isArray(payload.aud))) {
     throw new Error('Audience (aud) claim must be a string or array of strings present in the ID token');
@@ -74,7 +74,7 @@ var verify = (token, options) => {
   // --Time validation (epoch)--
   var now = Math.floor(Date.now() / 1000);
   var leeway = options.leeway || DEFAULT_LEEWAY;
-  
+
   // Expires at
   if (!payload.exp || typeof payload.exp !== 'number') {
     throw new Error('Expiration Time (exp) claim must be a number present in the ID token');
@@ -88,10 +88,6 @@ var verify = (token, options) => {
   // Issued at
   if (!payload.iat || typeof payload.iat !== 'number') {
     throw new Error('Issued At (iat) claim must be a number present in the ID token');
-  }
-  var iatTime = payload.iat - leeway;
-  if (now < iatTime) {
-    throw new Error(`Issued At (iat) claim error in the ID token; current time (${now}) is before issued at time (${iatTime})`);
   }
 
   // Nonce

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -101,7 +101,7 @@ describe('jwt.decode', function() {
       assert.throws(jwt.decode('test'), IDTOKEN_ERROR_MESSAGE);
       assert.throws(jwt.decode('test.'), IDTOKEN_ERROR_MESSAGE);
       assert.throws(jwt.decode('test.test'), IDTOKEN_ERROR_MESSAGE);
-      assert.throws(jwt.decode('test.test.test.test'), 
+      assert.throws(jwt.decode('test.test.test.test'),
         IDTOKEN_ERROR_MESSAGE
       );
     });
@@ -290,6 +290,17 @@ describe('jwt.verify', function() {
       done(new Error('Should have thrown error: ' + EXPECTED_ERROR_MESSAGE));
     } catch (error) {
       assert(error.message.includes(EXPECTED_ERROR_MESSAGE));
+      done();
+    }
+  });
+  it('should throw when Issued At is missing', function(done) {
+    var EXPECTED_ERROR_MESSAGE = 'Issued At (iat) claim must be a number present in the ID token';
+    try {
+      var token = generateJWT({ iat: undefined });
+      jwt.verify(token, expectedOptions)
+      done(new Error('Should have thrown error: ' + EXPECTED_ERROR_MESSAGE));
+    } catch (error) {
+      assert.equal(error.message, EXPECTED_ERROR_MESSAGE);
       done();
     }
   });


### PR DESCRIPTION
### Description

Removed the unnecessary value check for `iat` claims in the future.

### References

Internal: SDK-1276

### Testing

- [x] This change adds test coverage for presence check

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
