### PR TITLE
Added support for arbitrary params to be passed to auth0

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,20 @@ app.get(
 );
 ```
 
+### Additional Parameters
+
+If you want to set custom parameters not natively supported by the library:
+
+```js
+app.get(
+	'/login',
+	passport.authenticate('auth0', {additional_params: {'screen_hint': 'signup'}}),
+	function (req, res) {
+		res.redirect('/');
+	}
+);
+```
+
 ## Support + Feedback
 
 - Use [Issues](https://github.com/auth0/passport-auth0/issues) for code-level support

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,6 +92,9 @@ Strategy.prototype.authorizationParams = function(options) {
   var options = options || {};
 
   var params = {};
+  if (options.additional_params && typeof options.additional_params === 'object') {
+    Object.assign(params, options.additional_params);
+  }
   if (options.connection && typeof options.connection === 'string') {
     params.connection = options.connection;
 

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -155,6 +155,30 @@ describe('auth0 strategy', function () {
       should.not.exist(extraParams.acr_values);
     });
 
+    it('should map additional_params fields', function () {
+      var extraParams = this.strategy.authorizationParams({
+        additional_params: {
+          test_param: 'dummy:1',
+        }
+      });
+      extraParams.test_param.should.eql('dummy:1');
+    });
+
+    it('should override explicit fields set in additional_params', function () {
+      var extraParams = this.strategy.authorizationParams({
+        additional_params: {
+          acr_values: 2,
+        },
+        acr_values: 1
+      });
+      extraParams.acr_values.should.eql(2);
+    });
+
+    it('should not map additional_params fields if its not a object', function () {
+      var extraParams = this.strategy.authorizationParams({ additional_params: 42 });
+      Object.keys(extraParams).length.should.eql(0);
+    });
+
     it('should map the nonce field when authParams set on strategy', function () {
       this.strategy.authParams = { nonce: 'foo'};
       var extraParams = this.strategy.authorizationParams({});


### PR DESCRIPTION
# Description

This PR allows arbitrary URL parameters to be specified during the Auth0 login flow.

### References
Allow arbitrary URL parameters for login redirect #113 

### Testing

3 new tests were added which test the functionality of arbitrary parameters. 

1. Tests that arbitrary parameters are set on the params object if specified
2. Tests that arbitrary parameters are overridden by explicit parameters if specified
3. Tests that the arbitrary parameters field is not merged with the params object if it is not an object

Development Environment:
* macOS X 10.15.4
* NodeJS v12.15.0

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
