### PR TITLE
Allow sessionless authentication

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,15 +74,23 @@ Strategy.prototype.authenticate = function (req, options) {
     return this.fail(req.query.error);
   }
 
-  if (req.query.code) {
-    // If the code parameter is present, authenticate() is being called on the callback route.
-    this._verify = verifyWrapper(this._verify, this.options, req.session.authParams);
-  } else {
-    // If the code parameter is not present, authenticate() is being called on the login route.
-    req.session.authParams = {};
-    req.session.authParams.scope = options.scope;
-    req.session.authParams.nonce = crypto.randomBytes(16).toString('hex');
-    this.authParams = req.session.authParams
+  if (this.options.state) {
+    if (!req.session) {
+      throw new Error('Auth0Strategy requires you set state to false when no session is present')
+    }
+
+    if (req.query.code) {
+      // If the code parameter is present, authenticate() is being called on the callback route.
+      this._verify = verifyWrapper(this._verify, this.options, req.session.authParams);
+    } else {
+      // If the code parameter is not present, authenticate() is being called on the login route.
+      req.session.authParams = {};
+      req.session.authParams.scope = options.scope;
+      req.session.authParams.nonce = crypto.randomBytes(16).toString('hex');
+      this.authParams = req.session.authParams
+    }  
+  } else if (options.scope && options.scope.includes('openid')) {
+    throw new Error('Scope "openid" is not allowed without Auth0Strategy state true')
   }
 
   this._base.authenticate.call(this, req, options);


### PR DESCRIPTION
### Description
This library allowed sessionless authentication before 1.3.0 as state in https://github.com/auth0/passport-auth0#state-parameter

While sessionless is advised against, 1.3.0 introduced a breaking change to users that had state set to false and were not using sessions.  This PR rectifies that change.

Fixes #116 