### PR TITLE
Fix to not override option values with defaults.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function Strategy(options, verify) {
     apiUrl:           'https://' + options.domain + '/api'
   }
 
-  this.options = Object.assign({}, options, defaultOptions);
+  this.options = Object.assign({}, defaultOptions, options);
 
   if (this.options.state === undefined) {
     this.options.state = true;
@@ -88,7 +88,7 @@ Strategy.prototype.authenticate = function (req, options) {
       req.session.authParams.scope = options.scope;
       req.session.authParams.nonce = crypto.randomBytes(16).toString('hex');
       this.authParams = req.session.authParams
-    }  
+    }
   } else if (options.scope && options.scope.includes('openid')) {
     throw new Error('Scope "openid" is not allowed without Auth0Strategy state true')
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ function Strategy(options, verify) {
   );
 
   var defaultOptions = {
+    expectedIssuer:   'https://' + options.domain + '/',
     authorizationURL: 'https://' + options.domain + '/authorize',
     tokenURL:         'https://' + options.domain + '/oauth/token',
     userInfoURL:      'https://' + options.domain + '/userinfo',

--- a/lib/verifyWrapper.js
+++ b/lib/verifyWrapper.js
@@ -3,9 +3,9 @@ var jwt = require ('./jwt');
 /**
  * Adds ID token validation to Passport verification process.
  *
- * Parent passport-oauth2 library handles the verifier based on the number 
- * of arguments and changes the order if passReqToCallback is passed 
- * in with the strategy options. This wrapper will make the length of 
+ * Parent passport-oauth2 library handles the verifier based on the number
+ * of arguments and changes the order if passReqToCallback is passed
+ * in with the strategy options. This wrapper will make the length of
  * arguments consistent and add support for passReqToCallback.
  *
  * @param {Function} verify
@@ -29,16 +29,16 @@ function verifyWrapper (verify, strategyOptions, authParams) {
 
 /**
  * Perform ID token validation if an ID token was requested during login.
- * 
- * @param {Object} strategyOptions 
- * @param {Object} authParams 
- * @param {Object} params 
+ *
+ * @param {Object} strategyOptions
+ * @param {Object} authParams
+ * @param {Object} params
  */
 function handleIdTokenValidation (strategyOptions, authParams, params) {
   if (authParams && authParams.scope && authParams.scope.includes('openid')) {
     jwt.verify(params.id_token, {
       aud: strategyOptions.clientID,
-      iss: 'https://' + strategyOptions.domain + '/',
+      iss: strategyOptions.expectedIssuer,
       leeway: strategyOptions.leeway,
       maxAge: strategyOptions.maxAge,
       nonce: authParams.nonce

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -15,20 +15,58 @@ describe('auth0 strategy', function () {
     );
   });
 
-  it('authorizationURL should have the domain', function () {
-    this.strategy.options
-      .authorizationURL.should.eql('https://test.auth0.com/authorize');
+  describe('options', function() {
+    describe('defaults', function() {
+      it('authorizationURL should have the domain', function () {
+        this.strategy.options
+          .authorizationURL.should.eql('https://test.auth0.com/authorize');
+      });
+
+      it('tokenURL should have the domain', function () {
+        this.strategy.options
+          .tokenURL.should.eql('https://test.auth0.com/oauth/token');
+      });
+
+      it('userInfoURL should have the domain', function () {
+        this.strategy.options
+          .userInfoURL.should.eql('https://test.auth0.com/userinfo');
+      });
+
+      it('apiURL should have the domain', function () {
+        this.strategy.options
+          .apiUrl.should.eql('https://test.auth0.com/api');
+      });
+    });
+
+    it('should not override options with defaults', function() {
+      const strategy = new Auth0Strategy({
+          domain:       'test.auth0.com',
+          clientID:     'testid',
+          clientSecret: 'testsecret',
+          callbackURL:  '/callback',
+
+          authorizationURL: 'https://foobar.com/authorize',
+          tokenURL:         'https://foobar.com/oauth/token',
+          userInfoURL:      'https://foobar.com/userinfo',
+          apiUrl:           'https://foobar.com/api'
+        },
+        function(accessToken, idToken, profile, done) {}
+      );
+
+      strategy.options
+        .authorizationURL.should.eql('https://foobar.com/authorize');
+
+      strategy.options
+        .tokenURL.should.eql('https://foobar.com/oauth/token');
+
+      strategy.options
+        .userInfoURL.should.eql('https://foobar.com/userinfo');
+
+      strategy.options
+        .apiUrl.should.eql('https://foobar.com/api');
+    });
   });
 
-  it('tokenURL should have the domain', function () {
-    this.strategy.options
-      .tokenURL.should.eql('https://test.auth0.com/oauth/token');
-  });
-
-  it('userInfoURL should have the domain', function () {
-    this.strategy.options
-      .userInfoURL.should.eql('https://test.auth0.com/userinfo');
-  });
 
   it('should include a telemetry header by default', function() {
     var headers = this.strategy.options.customHeaders;

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -17,6 +17,11 @@ describe('auth0 strategy', function () {
 
   describe('options', function() {
     describe('defaults', function() {
+      it('expectedIssuer should have the domain', function () {
+        this.strategy.options
+        .expectedIssuer.should.eql('https://test.auth0.com/');
+      });
+
       it('authorizationURL should have the domain', function () {
         this.strategy.options
           .authorizationURL.should.eql('https://test.auth0.com/authorize');
@@ -45,6 +50,7 @@ describe('auth0 strategy', function () {
           clientSecret: 'testsecret',
           callbackURL:  '/callback',
 
+          expectedIssuer:   'https://foobar.com/',
           authorizationURL: 'https://foobar.com/authorize',
           tokenURL:         'https://foobar.com/oauth/token',
           userInfoURL:      'https://foobar.com/userinfo',
@@ -52,6 +58,9 @@ describe('auth0 strategy', function () {
         },
         function(accessToken, idToken, profile, done) {}
       );
+
+      strategy.options
+        .expectedIssuer.should.eql('https://foobar.com/');
 
       strategy.options
         .authorizationURL.should.eql('https://foobar.com/authorize');
@@ -66,7 +75,6 @@ describe('auth0 strategy', function () {
         .apiUrl.should.eql('https://foobar.com/api');
     });
   });
-
 
   it('should include a telemetry header by default', function() {
     var headers = this.strategy.options.customHeaders;


### PR DESCRIPTION
Also added extra test to check `options.apiUrl` had correct default assigned when missing.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes the strategy to not overwrite option values passed to the constructor with defaults.


### References

Fixes #126 

### Testing

`$ npm run test`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x]  All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
