### PR TITLE
Adding support for extra params to authorizeParams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,25 +99,39 @@ Strategy.prototype.authenticate = function (req, options) {
 Strategy.prototype.authorizationParams = function(options) {
   var options = options || {};
 
-  var params = {};
-  if (options.connection && typeof options.connection === 'string') {
-    params.connection = options.connection;
+  var {connection, connection_scope, audience, prompt, login_hint, acr_values, nonce, max_age} = options;
+  delete options.connection;
+  delete options.connection_scope;
+  delete options.audience;
+  delete options.prompt;
+  delete options.login_hint;
+  delete options.acr_values;
+  delete options.nonce;
+  delete options.max_age;
 
-    if (options.connection_scope && typeof options.connection_scope === 'string') {
-      params.connection_scope = options.connection_scope;
+  /*
+  When Node.js version 6 support is dropped, the above can be simplified to use,
+  var {connection, connection_scope, audience, prompt, login_hint, acr_values, nonce, max_age, ...extraParams} = options;
+  */
+  var params = Object.assign({}, options);
+  if (connection && typeof connection === 'string') {
+    params.connection = connection;
+
+    if (connection_scope && typeof connection_scope === 'string') {
+      params.connection_scope = connection_scope;
     }
   }
-  if (options.audience && typeof options.audience === 'string') {
-    params.audience = options.audience;
+  if (audience && typeof audience === 'string') {
+    params.audience = audience;
   }
-  if (options.prompt && typeof options.prompt === 'string') {
-    params.prompt = options.prompt;
+  if (prompt && typeof prompt === 'string') {
+    params.prompt = prompt;
   }
-  if (options.login_hint && typeof options.login_hint === 'string') {
-    params.login_hint = options.login_hint;
+  if (login_hint && typeof login_hint === 'string') {
+    params.login_hint = login_hint;
   }
-  if (options.acr_values && typeof options.acr_values === 'string') {
-    params.acr_values = options.acr_values;
+  if (acr_values && typeof acr_values === 'string') {
+    params.acr_values = acr_values;
   }
 
   var strategyOptions = this.options;

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,40 +98,51 @@ Strategy.prototype.authenticate = function (req, options) {
 
 Strategy.prototype.authorizationParams = function(options) {
   var options = options || {};
-
-  var {connection, connection_scope, audience, prompt, login_hint, acr_values, nonce, max_age} = options;
-  delete options.connection;
-  delete options.connection_scope;
-  delete options.audience;
-  delete options.prompt;
-  delete options.login_hint;
-  delete options.acr_values;
-  delete options.nonce;
-  delete options.max_age;
+  var params = Object.assign({}, options);
 
   /*
-  When Node.js version 6 support is dropped, the above can be simplified to use,
-  var {connection, connection_scope, audience, prompt, login_hint, acr_values, nonce, max_age, ...extraParams} = options;
-  */
-  var params = Object.assign({}, options);
-  if (connection && typeof connection === 'string') {
-    params.connection = connection;
+  You might wonder why we have delete statements here?
+  The objective is to make it possible for consumers to use the API like this:
 
-    if (connection_scope && typeof connection_scope === 'string') {
-      params.connection_scope = connection_scope;
+    passport.authenticate('auth0', {
+      scope: 'openid email profile',
+      'my_custom_extra_param': true // <== An extra param
+    })
+
+  To keep the validation of all expected options, we therefore take a copy
+  and delete the "reserved" options. This leaves us with any extra params.
+  When node.js version 6 is dropped at one point, this can be done in a single 
+  line of code 😇
+
+  const {connection, connection_scope, audience, prompt, login_hint, acr_value, nonce, max_age, ...theRest} = options;
+  */
+  delete params.connection;
+  delete params.connection_scope;
+  delete params.audience;
+  delete params.prompt;
+  delete params.login_hint;
+  delete params.acr_values;
+  delete params.nonce;
+  delete params.max_age;
+
+  if (options.connection && typeof options.connection === 'string') {
+    params.connection = options.connection;
+
+    if (options.connection_scope && typeof options.connection_scope === 'string') {
+      params.connection_scope = options.connection_scope;
     }
   }
-  if (audience && typeof audience === 'string') {
-    params.audience = audience;
+  if (options.audience && typeof options.audience === 'string') {
+    params.audience = options.audience;
   }
-  if (prompt && typeof prompt === 'string') {
-    params.prompt = prompt;
+  if (options.prompt && typeof options.prompt === 'string') {
+    params.prompt = options.prompt;
   }
-  if (login_hint && typeof login_hint === 'string') {
-    params.login_hint = login_hint;
+  if (options.login_hint && typeof options.login_hint === 'string') {
+    params.login_hint = options.login_hint;
   }
-  if (acr_values && typeof acr_values === 'string') {
-    params.acr_values = acr_values;
+  if (options.acr_values && typeof options.acr_values === 'string') {
+    params.acr_values = options.acr_values;
   }
 
   var strategyOptions = this.options;

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -198,6 +198,12 @@ describe('auth0 strategy', function () {
       should.exist(extraParams.my_custom_param1);
       should.exist(extraParams.my_custom_param2);
     });
+
+    it('Should be pure', function() {
+      var params = {connection: '123'};
+      this.strategy.authorizationParams(params);
+      should.exist(params.connection);
+    });
   });
 
   describe('authenticate', function () {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -187,6 +187,17 @@ describe('auth0 strategy', function () {
       var extraParams = this.strategy.authorizationParams({});
       should.not.exist(extraParams.max_age);
     });
+
+    it('should add extra params, if provided', function () {
+      var extraParams = this.strategy.authorizationParams({my_custom_param: true});
+      should.exist(extraParams.my_custom_param);
+    });
+
+    it('should multiple extra params, if provided', function () {
+      var extraParams = this.strategy.authorizationParams({my_custom_param1: true, my_custom_param2: 123});
+      should.exist(extraParams.my_custom_param1);
+      should.exist(extraParams.my_custom_param2);
+    });
   });
 
   describe('authenticate', function () {


### PR DESCRIPTION
This makes passport-auth0 consistent with other Auth0 libraries,
because it makes it possible to add extra params.

### Description

Passport-auth0 does not currently support adding extra params, inconsistent with the universal login experience. By allowing extra params, we can configure extraParams, accessible from inside Auth0 universal login. So with this PR you can now submit extra params to the config object:

```typescript
// After this PR, developers can use passport like this:
passport.authenticate('auth0', {
        scope: 'openid email profile',
        'my_custom_extra_param': true // This is the extra param
}),
```

```typescript
// This can now be accessed in universal login like this:
// This is extremely usefull for customising the user experience, and is also documented by Auth0.
config.extraParams['my_custom_extra_param']
```

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
