### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [v1.4.0](https://github.com/auth0/passport-auth0/tree/v1.4.0) (2020-10-22)
+[Full Changelog](https://github.com/auth0/passport-auth0/compare/v1.4.0...v1.3.3)
+
+**Added**
+Adding support for extra params to authorizeParams [\#131](https://github.com/auth0/passport-auth0/pull/131) ([alexbjorlig](https://github.com/alexbjorlig))
+
+**Security**
+Bump lodash from 4.17.15 to 4.17.20  [\#129](https://github.com/auth0/passport-auth0/pull/129)
+
+**Fixed**
+Fix to not override option values with defaults. [\#127](https://github.com/auth0/passport-auth0/pull/127) ([kierans](https://github.com/alexbjorlig))
+
 ## [v1.3.3](https://github.com/auth0/passport-auth0/tree/v1.3.3) (2020-06-05)
 [Full Changelog](https://github.com/auth0/passport-auth0/compare/v1.3.3...v1.3.2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-auth0",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-auth0",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Auth0 platform authentication strategy for Passport.js",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## [v1.4.0](https://github.com/auth0/passport-auth0/tree/v1.4.0) (2020-10-22)
[Full Changelog](https://github.com/auth0/passport-auth0/compare/v1.4.0...v1.3.3)

**Added**
Adding support for extra params to authorizeParams [\#131](https://github.com/auth0/passport-auth0/pull/131) ([alexbjorlig](https://github.com/alexbjorlig))

**Security**
Bump lodash from 4.17.15 to 4.17.20  [\#129](https://github.com/auth0/passport-auth0/pull/129)

**Fixed**
Fix to not override option values with defaults. [\#127](https://github.com/auth0/passport-auth0/pull/127) ([kierans](https://github.com/alexbjorlig))
