### PR TITLE
Run CI on Node 12, 14 and 16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,15 @@ workflows:
       - test:
           name: test_node8
           v: "8"
+      - test:
+          name: test_node12
+          v: "12"
+      - test:
+          name: test_node14
+          v: "14"
+      - test:
+          name: test_node16
+          v: "16"
 jobs:
   test:
     parameters:


### PR DESCRIPTION
Currently, CI only runs on Node 6 and 8. This PR ensures it also runs on Node 12, 14 and 16. We might want to consider dropping Node 6 and 8 in the near future.