### PR TITLE
Add missing commas so that "use strict" works

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,8 @@
 var util = require('util'),
   OAuth2Strategy = require('passport-oauth').OAuth2Strategy,
   axios = require('axios'),
-  pkg = require('../package.json')
-  crypto = require('crypto')
+  pkg = require('../package.json'),
+  crypto = require('crypto'),
   querystring = require('querystring');
 
 function encodeClientInfo(obj) {


### PR DESCRIPTION
Co-Authored-By: jpaddison3 <jp@centreforeffectivealtruism.org>

When we experimented with adding "use strict" to our codebase in a way that accidentally covered all of `node_modules`, this file crashed on start because `crypto` is an assignment to an undeclared variable. It's an undeclared variable because the preceding line is missing a comma. Fix that, so that this file can pass `use strict`.