### PR TITLE
Only run CI against supported Node versions (12+)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
           name: test_node16
           v: "16"
       - test:
-          name: test_node16
+          name: test_node18
           v: "18"
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,12 +5,6 @@ workflows:
   test:
     jobs:
       - test:
-          name: test_node6
-          v: "6"
-      - test:
-          name: test_node8
-          v: "8"
-      - test:
           name: test_node12
           v: "12"
       - test:
@@ -19,12 +13,15 @@ workflows:
       - test:
           name: test_node16
           v: "16"
+      - test:
+          name: test_node16
+          v: "18"
 jobs:
   test:
     parameters:
       v:
         type: string
-        default: "6"
+        default: "12"
     docker:
       - image: circleci/node:<< parameters.v >>
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
           v: "16"
       - test:
           name: test_node18
-          v: "18"
+          v: "lts"
 jobs:
   test:
     parameters:


### PR DESCRIPTION
### Description

Needed to merge #166 , as mocha's latest does not work on Node <12.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
