### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,6 @@ on:
 permissions:
   contents: read
   id-token: write # For publishing to NPM with provenance. Allows developers to run `npm audit signatures` and verify release signature of SDK. @see https://github.blog/2023-04-19-introducing-npm-package-provenance/
-  packages: write # For cross-publishing to GitHub Packages registry.
 
 env:
   NODE_VERSION: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
@@ -107,31 +108,3 @@ jobs:
         run: npm publish --provenance --tag ${{ needs.configure.outputs.vtag }} ${{ needs.configure.outputs.dry-run }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-  publish-gh:
-    needs:
-      - configure
-      - publish-npm # Don't publish to GitHub Packages until publishing to NPM is successfully completed
-
-    name: Publish to GitHub Packages
-    runs-on: ubuntu-latest
-    environment: 'release'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: 'https://npm.pkg.github.com'
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Publish release to GitHub Packages
-        run: npm publish --provenance --tag ${{ needs.configure.outputs.vtag }} ${{ needs.configure.outputs.dry-run }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

- Removed releasing to GH Packages as we haven't done that before.
- Added registry-url to setup-node as that's required in order for the `NODE_AUTH_TOKEN` to be used, see 
  - https://github.com/actions/setup-node/blob/main/src/main.ts#L59-L61
  - https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
- Added dependabot config for npm

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
