### PR TITLE
chore: use HTTPS package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/auth0/passport-auth0"
+    "url": "https://github.com/auth0/passport-auth0"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Updates package metadata to use HTTPS GitHub URLs instead of legacy unauthenticated URLs.

Validation:
- `git diff --check`
- parsed `package.json` with Node.js